### PR TITLE
escape file name before calling edit

### DIFF
--- a/lua/fm-nvim.lua
+++ b/lua/fm-nvim.lua
@@ -60,7 +60,7 @@ end
 local function checkFile(file)
     if io.open(file, "r") ~= nil then
         for line in io.lines(file) do
-            vim.cmd(method .. " " .. line)
+            vim.cmd(method .. " " .. vim.fn.fnameescape(line))
         end
         method = config.edit_cmd
         io.close(io.open(file, "r"))


### PR DESCRIPTION
While using Remix, there are file names that start with `$`, opening those files with broot will not open the file in question
this PR just escapes paths before calling edit